### PR TITLE
Fixing CLI in Linux systems

### DIFF
--- a/bin/s3-folder-upload.js
+++ b/bin/s3-folder-upload.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --harmony
+#!/usr/bin/env node
 
 'use strict'
 


### PR DESCRIPTION
Full error: `usr/bin/env: 'node --harmony': No such file or directory`

I believe this works nowhere except on Mac OS X, as `env` utility does not take parameters.

Also, we don't need this switch nowdays as the node understands ES6 natively now.