### PR TITLE
Feat/add logging level system

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ s3FolderUpload(directoryName, credentials, options, invalidation)
 
 `uploadFolder` (default: `undefined`) - If it's specified, the statics will be uploaded to the folder, so if you upload `static.js` to `https://statics.s3.eu-west-1.amazonaws.com` with a `uploadFolder` with value `my-statics` the file will be uploaded to: `https://statics.s3.eu-west-1.amazonaws.com/my-statics/static.js`.
 
-
 ## CLI
 ```bash
 s3-folder-upload <folder>
@@ -92,6 +91,23 @@ s3-folder-upload statics
 * you can pass the needed info via command line parameters, the invalidation needs both parameters:
     ```bash
     s3-folder-upload <folder> <credentials parameters> --awsDistributionId=<distributionId> --awsInvalidationPath="/js/*"
+
+### Environment Variables
+`S3_FOLDER_UPLOAD_LOG`: You could specify the level of logging for the library.
+* `none`: No logging output
+* `only_errors`: Only errors are logged
+* `all` (default): Errors, progress and useful messages are logged.
+
+Example of use:
+```
+S3_FOLDER_UPLOAD_LOG=only_errors s3-folder-upload <folder>
+```
+
+If you use the library programatically, this ENVIRONEMNT_VARIABLE will be read as well. For example:
+
+```
+S3_FOLDER_UPLOAD_LOG=only_errors node upload-script.js
+```
 
 ## Wish list
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -1,16 +1,17 @@
-'use strict'
+const logUpdate = require('log-update')
 
+const {CONTINUOUS_INTEGRATION, S3_FOLDER_UPLOAD_LOG} = process.env
 const FRAMES = ['-', '\\', '|', '/']
 const LOG_LEVELS = {
   all: 2,
   only_errors: 1,
   none: 0
 }
-const {S3_FOLDER_UPLOAD_LOG} = process.env
-const LOG = LOG_LEVELS[S3_FOLDER_UPLOAD_LOG] || LOG_LEVELS.all
+const DEFAULT_LOG_LEVEL = CONTINUOUS_INTEGRATION
+  ? LOG_LEVELS.only_errors
+  : LOG_LEVELS.all
+const LOG = LOG_LEVELS[S3_FOLDER_UPLOAD_LOG] || DEFAULT_LOG_LEVEL
 let loadingPosition = 0
-
-const logUpdate = require('log-update')
 
 module.exports = {
   error(err, forceExit) {

--- a/lib/output.js
+++ b/lib/output.js
@@ -1,28 +1,37 @@
 'use strict'
 
 const FRAMES = ['-', '\\', '|', '/']
+const LOG_LEVELS = {
+  all: 2,
+  only_errors: 1,
+  none: 0
+}
+const {S3_FOLDER_UPLOAD_LOG} = process.env
+const LOG = LOG_LEVELS[S3_FOLDER_UPLOAD_LOG] || LOG_LEVELS.all
 let loadingPosition = 0
 
 const logUpdate = require('log-update')
 
 module.exports = {
   error(err, forceExit) {
-    console.error('\x1b[31m%s\x1b[0m', err)
+    LOG > LOG_LEVELS.none && console.error('\x1b[31m%s\x1b[0m', err)
     if (forceExit) {
       process.exit(1)
     }
   },
 
   info(msg) {
-    console.log('\x1b[33m%s\x1b[0m', msg)
+    LOG > LOG_LEVELS.only_errors && console.log('\x1b[33m%s\x1b[0m', msg)
   },
 
   progress(msg, clean) {
-    const frame = clean ? '' : FRAMES[loadingPosition++ % FRAMES.length]
-    logUpdate(`${frame} ${msg}`)
+    if (LOG > LOG_LEVELS.only_errors) {
+      const frame = clean ? '' : FRAMES[loadingPosition++ % FRAMES.length]
+      logUpdate(`${frame} ${msg}`)
+    }
   },
 
   success(msg) {
-    console.log('\x1b[32m%s\x1b[0m', msg)
+    LOG > LOG_LEVELS.only_errors && console.log('\x1b[32m%s\x1b[0m', msg)
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "homepage": "https://github.com/miduga/s3-folder-upload/#readme",
   "dependencies": {
-    "async": "3.1.0",
-    "aws-sdk": "2.603.0",
+    "async": "3.2.0",
+    "aws-sdk": "2.647.0",
     "globby": "10.0.1",
     "log-update": "3.3.0",
-    "minimist": "1.2.0"
+    "minimist": "1.2.5"
   },
   "devDependencies": {
-    "np": "5.2.1",
+    "np": "6.2.0",
     "@s-ui/lint": "3",
     "chai": "4",
     "mocha": "5",


### PR DESCRIPTION
This fixes #9 .

It adds a way to disable logging by using environment variables.

By default: for CI, the log_level will be `only_errors`. If not CI, then `all`.
New `none` to completely silent logging.